### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Standards-Version: 4.6.0
 Section: libs
 Homepage: https://github.com/pmem/vmemcache
 Vcs-Browser: https://github.com/kilobyte/vmemcache/tree/debian
-Vcs-Git: https://github.com/kilobyte/vmemcache -b debian
+Vcs-Git: https://github.com/kilobyte/vmemcache.git -b debian
 
 Package: libvmemcache-dev
 Section: libdevel

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
 	pandoc,
 	pkg-config,
 	valgrind-if-available,
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Section: libs
 Homepage: https://github.com/pmem/vmemcache
 Vcs-Browser: https://github.com/kilobyte/vmemcache/tree/debian


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/vmemcache/06d8b8ef-27ab-4d6c-9952-fe95a069c880.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/06d8b8ef-27ab-4d6c-9952-fe95a069c880/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/06d8b8ef-27ab-4d6c-9952-fe95a069c880/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/06d8b8ef-27ab-4d6c-9952-fe95a069c880/diffoscope)).
